### PR TITLE
FIM permutations

### DIFF
--- a/fim.py
+++ b/fim.py
@@ -1,0 +1,80 @@
+import functools
+
+import numpy as np
+
+
+# this is expensive so we cache it
+@functools.lru_cache(maxsize=None)
+def get_fim_token_ids(tokenizer):
+    _, FIM_PREFIX, FIM_MIDDLE, FIM_SUFFIX, FIM_PAD = tokenizer.special_tokens_map[
+        "additional_special_tokens"
+    ]
+    suffix_tok_id, prefix_tok_id, middle_tok_id, pad_tok_id = (
+        tokenizer.vocab[tok] for tok in [FIM_SUFFIX, FIM_PREFIX, FIM_MIDDLE, FIM_PAD]
+    )
+    return suffix_tok_id, prefix_tok_id, middle_tok_id, pad_tok_id
+
+
+## Adapted from https://github.com/bigcode-project/Megatron-LM/blob/6c4bf908df8fd86b4977f54bf5b8bd4b521003d1/megatron/data/gpt_dataset.py
+def permute(
+    sample,
+    np_rng,
+    suffix_tok_id,
+    prefix_tok_id,
+    middle_tok_id,
+    pad_tok_id,
+    fim_rate=0.5,
+    fim_spm_rate=0.5,
+    truncate_or_pad=False,
+):
+    """
+    Take in a sample (list of tokens) and perform a FIM transformation on it with a probability of fim_rate, using two FIM modes:
+    PSM and SPM (with a probability of fim_spm_rate).
+    """
+
+    if np_rng.binomial(1, fim_rate):
+        boundaries = list(np_rng.randint(low=0, high=len(sample) + 1, size=2))
+        boundaries.sort()
+
+        prefix = np.array(sample[: boundaries[0]], dtype=np.int64)
+        middle = np.array(sample[boundaries[0] : boundaries[1]], dtype=np.int64)
+        suffix = np.array(sample[boundaries[1] :], dtype=np.int64)
+
+        if truncate_or_pad:
+            new_length = suffix.shape[0] + prefix.shape[0] + middle.shape[0] + 3
+            diff = new_length - len(sample)
+            if diff > 0:
+                if suffix.shape[0] <= diff:
+                    return sample, np_rng
+                suffix = suffix[: suffix.shape[0] - diff]
+            elif diff < 0:
+                suffix = np.concatenate([suffix, np.full((-1 * diff), pad_tok_id)])
+
+        if np_rng.binomial(1, fim_spm_rate):
+            # SPM (variant 2 from FIM paper)
+            new_sample = np.concatenate(
+                [
+                    [prefix_tok_id, suffix_tok_id],
+                    suffix,
+                    [middle_tok_id],
+                    prefix,
+                    middle,
+                ]
+            )
+        else:
+            # PSM
+            new_sample = np.concatenate(
+                [
+                    [prefix_tok_id],
+                    prefix,
+                    [suffix_tok_id],
+                    suffix,
+                    [middle_tok_id],
+                    middle,
+                ]
+            )
+    else:
+        # don't do FIM preproc
+        new_sample = sample
+
+    return list(new_sample), np_rng

--- a/train.py
+++ b/train.py
@@ -122,9 +122,8 @@ def permute(sample, np_rng, tokenizer, fim_rate=0.5, fim_spm_rate=0.5, truncate_
         if np_rng.binomial(1, fim_spm_rate):
             # SPM (variant 2 from FIM paper)
             new_sample = np.concatenate([
-                [suffix_tok_id], suffix,
-                [prefix_tok_id], prefix,
-                [middle_tok_id], middle
+                [prefix_tok_id, suffix_tok_id], suffix,
+                [middle_tok_id], prefix, middle
             ])
         else:
             # PSM


### PR DESCRIPTION
Here is a draft that adds optional FIM permutations while finetuning. Some things I was hoping to get feedback on

- I added the permuting as part of the `ConstantLengthDataset` class. Is that the right place to do this?

- With FIM enabled, batches take ~2x as long to load. Is this acceptable? Here are the stats for loading 5 batches with and without FIM on my Intel MacBook Pro
```
FIM time: 66.68208975399999
Non-FIM time: 32.142377584
```

- I cannot actually test that the training still works on the script because I don't have access to a GPU. The training seems to work in the [Colab I adapted](https://colab.research.google.com/drive/1CADU0YxD3p7pLivgST0toYFLUdGWDP5f) but this should be checked to make sure all is still well