### PR TITLE
Added the ability to train with bf16 through arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ wandb login
 
 3. The following examples show how you can launch fine-tuning for The Stack dataset. 
 Here we will run the script on the *Ruby* subset of the dataset for demonstration purposes. Note that:
-- Gradient Checkpointing is enabled by default and the caching mechanism is disabled to save memory. If you want to disable them call `no_gradient_checkpointing` argument. Note that mixed precision is disabled with the `no_fp16` flag due to some issues we noticed when using it, you can enable it by removing that argument. However, a better choice would be to use bf16 mixed percision which is enabled with the `bf16` flag as it is a more stable form of mixed precision training.
+- Gradient Checkpointing is enabled by default and the caching mechanism is disabled to save memory. If you want to disable them call `no_gradient_checkpointing` argument. Note that mixed precision is disabled with the `no_fp16` flag due to some issues we noticed when using it, you can enable it by removing that argument. However, a better choice would be to use bf16 mixed precision, if it's supported on your hardware (e.g A100), it's enabled with the `bf16` flag and can be more stable in training.
 - If the model still doesn't fit in your memory use `batch_size` 1 and reduce `seq_length` to 1024 for example.
 - If you want to use [streaming](https://huggingface.co/docs/datasets/stream) and avoid downloading the entire dataset, add the flag `streaming`.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ wandb login
 
 3. The following examples show how you can launch fine-tuning for The Stack dataset. 
 Here we will run the script on the *Ruby* subset of the dataset for demonstration purposes. Note that:
-- Gradient Checkpointing is enabled by default and the caching mechanism is disabled to save memory. If you want to disable them call `no_gradient_checkpointing` argument. Note that Mixed precision is disabled with the `no_fp16` flag due to some issues we noticed when using it, you can enable it by removing that argument.
+- Gradient Checkpointing is enabled by default and the caching mechanism is disabled to save memory. If you want to disable them call `no_gradient_checkpointing` argument. Note that mixed precision is disabled with the `no_fp16` flag due to some issues we noticed when using it, you can enable it by removing that argument. However, a better choice would be to use bf16 mixed percision which is enabled with the `bf16` flag as it is a more stable form of mixed precision training.
 - If the model still doesn't fit in your memory use `batch_size` 1 and reduce `seq_length` to 1024 for example.
 - If you want to use [streaming](https://huggingface.co/docs/datasets/stream) and avoid downloading the entire dataset, add the flag `streaming`.
 

--- a/train.py
+++ b/train.py
@@ -45,6 +45,7 @@ def get_args():
 
     parser.add_argument("--local_rank", type=int, default=0)
     parser.add_argument("--no_fp16", action="store_false")
+    parser.add_argument("--bf16", action="store_true")
     parser.add_argument("--no_gradient_checkpointing", action="store_false")
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--num_workers", type=int, default=None)
@@ -52,6 +53,7 @@ def get_args():
     parser.add_argument("--log_freq", default=1, type=int)
     parser.add_argument("--eval_freq", default=1000, type=int)
     parser.add_argument("--save_freq", default=1000, type=int)
+    
     return parser.parse_args()
 
 
@@ -201,6 +203,7 @@ def run_training(args, train_data, val_data):
         gradient_accumulation_steps=args.gradient_accumulation_steps,
         gradient_checkpointing=args.no_gradient_checkpointing,
         fp16=args.no_fp16,
+        bf16=args.bf16,
         weight_decay=args.weight_decay,
         run_name=f"santacoder-{args.subset}",
         report_to="wandb",


### PR DESCRIPTION
While fp16 causes error while training, I used bf16 for training and saw that it worked fine. I added the ability to enable this option through arguments and added an explanation to the tutorial. By default bf16 is off, but if you enable both the `no_fp16` flag and `bf16` flag, you train using mixed precision bf16. 