### PR TITLE
Make FIM optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Here we will run the script on the *Ruby* subset of the dataset for demonstratio
 - Gradient Checkpointing is enabled by default and the caching mechanism is disabled to save memory. If you want to disable them call `no_gradient_checkpointing` argument. Note that mixed precision is disabled with the `no_fp16` flag due to some issues we noticed when using it, you can enable it by removing that argument. However, a better choice would be to use bf16 mixed precision, if it's supported on your hardware (e.g A100), it's enabled with the `bf16` flag and can be more stable in training.
 - If the model still doesn't fit in your memory use `batch_size` 1 and reduce `seq_length` to 1024 for example.
 - If you want to use [streaming](https://huggingface.co/docs/datasets/stream) and avoid downloading the entire dataset, add the flag `streaming`.
-
+- If you want to train your model with Fill-In-The-Middle ([FIM](https://arxiv.org/abs/2207.14255)), use a tokenizer that includes FIM tokens, like SantaCoder's and specify the FIM rate arguments `fim_rate` and `fim_spm_rate` (by default they are 0, for SantaCoder we use 0.5 for both). 
 
 ```bash
 python train.py \

--- a/fim.py
+++ b/fim.py
@@ -6,12 +6,15 @@ import numpy as np
 # this is expensive so we cache it
 @functools.lru_cache(maxsize=None)
 def get_fim_token_ids(tokenizer):
-    _, FIM_PREFIX, FIM_MIDDLE, FIM_SUFFIX, FIM_PAD = tokenizer.special_tokens_map[
-        "additional_special_tokens"
-    ]
-    suffix_tok_id, prefix_tok_id, middle_tok_id, pad_tok_id = (
-        tokenizer.vocab[tok] for tok in [FIM_SUFFIX, FIM_PREFIX, FIM_MIDDLE, FIM_PAD]
-    )
+    try:
+        _, FIM_PREFIX, FIM_MIDDLE, FIM_SUFFIX, FIM_PAD = tokenizer.special_tokens_map[
+            "additional_special_tokens"
+        ]
+        suffix_tok_id, prefix_tok_id, middle_tok_id, pad_tok_id = (
+            tokenizer.vocab[tok] for tok in [FIM_SUFFIX, FIM_PREFIX, FIM_MIDDLE, FIM_PAD]
+        )
+    except KeyError:
+        suffix_tok_id, prefix_tok_id, middle_tok_id, pad_tok_id = None, None, None, None
     return suffix_tok_id, prefix_tok_id, middle_tok_id, pad_tok_id
 
 

--- a/train.py
+++ b/train.py
@@ -56,8 +56,8 @@ def get_args():
     parser.add_argument("--eval_freq", default=1000, type=int)
     parser.add_argument("--save_freq", default=1000, type=int)
 
-    parser.add_argument("--fim_rate", type=float, default=0.5)
-    parser.add_argument("--fim_spm_rate", type=float, default=0.5)
+    parser.add_argument("--fim_rate", type=float, default=0)
+    parser.add_argument("--fim_spm_rate", type=float, default=0)
     return parser.parse_args()
 
 
@@ -121,6 +121,9 @@ class ConstantLengthDataset(IterableDataset):
             self.middle_tok_id,
             self.pad_tok_id,
         ) = fim.get_fim_token_ids(self.tokenizer)
+        if not self.suffix_tok_id and self.fim_rate > 0:
+            print("FIM is not supported by tokenizer, disabling FIM")
+            self.fim_rate = 0
 
     def __iter__(self):
         iterator = iter(self.dataset)


### PR DESCRIPTION
This PR by @Stillerman added support to [FIM](https://github.com/loubnabnl/santacoder-finetuning/pull/8) for santacoder fine-tuning:rocket: 
But since this code is used not just for SantaCoder this PR changes default fim rates to zero, and handles case where user specifies `fim_rate>0` and tokenizer doesn't have fim tokens.